### PR TITLE
Fix enums

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ async function startSave(data) {
   // Evolands 1 (Legendary edition)
   savegames.push({
     label: 'Evoland 1 (Legendary edition)',
+    disabled:true,
     content: await serialize({
       data: data.data || data,
       game: { args: [], __enum_name: 'GameType', ...data.game, __enum_tag: 'Evo1' },


### PR DESCRIPTION
# Changes

- Added small parse which fixes #1 for Evoland 2 saves. 
- Correctly marks evo1 saves as broken, and disables them (they are still broken).

# Tested?

I tested this on my local save of evoland 2 with success (managed to finally unlock an achievement that I unlocked in offline mode).

I also tested this on my local save of evoland 1 where I noticed the problems with using regex to fix this.

Both savefiles were from an endgame state.

# Improvements?

A better fix could be

- create small custom parser which can detect enums and replace them in the serialized code accordingly
- switch to haxe for (de)serialization of the data. With haxe, you can (to be verified) define the enums as they are defined in the save file, allowing the enum to be recognized by the haxe serializer. This is impossible with the current implementation.
